### PR TITLE
Hotfix/20210108

### DIFF
--- a/acf-additional-hint.php
+++ b/acf-additional-hint.php
@@ -3,7 +3,7 @@
  * Plugin Name: ACF Additional Hint
  * Plugin URI:
  * Description: A plugin to add help/hint text in ACF field.
- * Version: 1.2
+ * Version: 1.3
  * Author: PRESSMAN
  * Author URI: https://www.pressman.ne.jp/
  * Text Domain: acf-additional-hint

--- a/css/style.css
+++ b/css/style.css
@@ -14,6 +14,20 @@
     padding: 0;
     font-weight: normal;
 }
+.acf-hint-tooltip::after {
+    display: none;
+    content: "";
+    position: absolute;
+    top: -2px;
+    left: 26px;
+    border: 13px solid transparent;
+    border-top: 15px solid #d3eef7;
+    margin-left: -15px;
+    transform: rotateZ(90deg);
+}
+.acf-hint-tooltip.hover::after {
+    display: block;
+}
 
 .hint-icon {
     cursor: pointer;
@@ -36,18 +50,7 @@
     word-wrap: break-word;
 }
 
-.acf-hint-description:before {
-    content: "";
-    position: absolute;
-    top: 3%;
-    right: 98%;
-    border: 13px solid transparent;
-    border-top: 15px solid #d3eef7;
-    margin-left: -15px;
-    transform: rotateZ(90deg);
-}
-
-.acf-hint-tooltip:hover .acf-hint-description {
+.acf-hint-tooltip.hover .acf-hint-description {
     display: inline-block;
     top: -8px;
     left: 33px;

--- a/js/main.js
+++ b/js/main.js
@@ -21,4 +21,24 @@ jQuery(function( $ ) {
 	$( 'td.acf-label:has(label[for$="hint_text"])' ).addClass( 'row-border-none' );
 	$( 'td.acf-input:has([id$="hint_text"])' ).addClass( 'row-border-none' );
 
+	// Hover event for tooltip.
+	$( '.acf-hint-tooltip' ).hover(
+		function () {
+			var documentHeight = $( document ).height();
+			$( this ).addClass( 'hover' );
+
+			var $description = $( this ).children( '.acf-hint-description' );
+			$description.css( 'margin-top', '' );
+
+			var descPosition = $description.offset(),
+				descHeight = $description.outerHeight();
+
+			if ( documentHeight < descPosition.top + descHeight + 20 ) {
+				$description.css( 'margin-top', documentHeight - ( descPosition.top + descHeight + 20 ) );
+			}
+		},
+		function () {
+			$( this ).removeClass( 'hover' );
+		}
+	);
 });

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === ACF Additional Hint ===
-Contributors: pressmaninc, hommakoharu, hiroshisekiguchi, kazunao, muraokashotaro
+Contributors: pressmaninc, hommakoharu, hiroshisekiguchi, kazunao, muraokashotaro, kengotakeuchi
 Tags: acf, advanced, custom, field, fields, hint, help
 Requires at least: 4.6
-Tested up to: 5.3
-Stable tag: 1.2
+Tested up to: 5.6
+Stable tag: 1.3
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -37,6 +37,9 @@ OR
 3. Examples of the icon option
 
 == Changelog ==
+
+= 1.3 =
+* Bugfix.
 
 = 1.0 =
 * First version.


### PR DESCRIPTION
tooltipがページの高さを超えてページのスクロール量が変化した際
tooltipを表示したままスクロールすると表示のオンオフを繰り返してしまうことがあるため
tooltipがページ内に収まるよう以下の通り調整しました。

- tooltip表示時にページの高さを取得＞tooltipが高さを超える場合に表示位置を上にずらしてページ内に収める
- ページの高さを取得する際、cssの:hoverだとtooltipで伸びた後の高さになるためcssの:hoverをやめ、ページの高さ取得後にhoverクラスを追加してstyleを切り替え
- 吹き出しの▲が常に同じ位置になるようhoverするアイコン側の::afterに移動