### PR TITLE
文章の長さに応じてツールチップのwidthが変化するように修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -37,20 +37,19 @@
 }
 
 .acf-hint-description {
-    display: none;
-    position: absolute;
+    opacity: 0;
     padding: 10px;
     font-size: 12px;
     line-height: 1.6em;
     color: #000000;
     border-radius: 5px;
     background: #d3eef7;
-    width: 200px;
     z-index: 10;
     word-wrap: break-word;
 }
 
 .acf-hint-tooltip.hover .acf-hint-description {
+    opacity: 1;
     display: inline-block;
     top: -8px;
     left: 33px;

--- a/css/style.css
+++ b/css/style.css
@@ -37,7 +37,8 @@
 }
 
 .acf-hint-description {
-    opacity: 0;
+    display: none;
+    position: absolute;
     padding: 10px;
     font-size: 12px;
     line-height: 1.6em;
@@ -49,7 +50,6 @@
 }
 
 .acf-hint-tooltip.hover .acf-hint-description {
-    opacity: 1;
     display: inline-block;
     top: -8px;
     left: 33px;

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,20 @@
 jQuery(function( $ ) {
+	let tooltipWidths = {};
+
 	// Change position of tooltips and switch button.
 	$( '.acf-hint-tooltip, .btn-area' ).each(function() {
+		// Get and save width now because I can't get width after setting position property.
+		const width = $( this ).children( '.acf-hint-description' ).width();
+		const dataKey = $( this ).data( 'key' );
+		if ( $( this ).hasClass( 'acf-hint-tooltip' ) ) {
+			tooltipWidths[ dataKey ] = width + 1;
+		}
+
+		// Initialize styles for loading screen.
+		$( this ).children( '.acf-hint-description' ).css( 'position', 'absolute' );
+		$( this ).children( '.acf-hint-description' ).css( 'display', 'none' );
+
+		// Change position of tooltips and switch button.
 		var $node = $( this ).parent().siblings( '.acf-label' ).find( 'label' );
 		$( this ).appendTo( $node );
 	});
@@ -30,6 +44,14 @@ jQuery(function( $ ) {
 			var $description = $( this ).children( '.acf-hint-description' );
 			$description.css( 'margin-top', '' );
 
+			// Set width of the tooltip.
+			const key = $( this ).data( 'key' );
+			const width = tooltipWidths[ key ];
+			$description.width( width );
+
+			// Display tooltip on screen.
+			$description.css( 'display', 'inline-block' );
+
 			var descPosition = $description.offset(),
 				descHeight = $description.outerHeight();
 
@@ -39,6 +61,7 @@ jQuery(function( $ ) {
 		},
 		function () {
 			$( this ).removeClass( 'hover' );
+			$( this ).children( '.acf-hint-description' ).css( 'display', 'none' );
 		}
 	);
 });

--- a/js/main.js
+++ b/js/main.js
@@ -1,19 +1,6 @@
 jQuery(function( $ ) {
-	let tooltipWidths = {};
-
 	// Change position of tooltips and switch button.
 	$( '.acf-hint-tooltip, .btn-area' ).each(function() {
-		// Get and save width now because I can't get width after setting position property.
-		const width = $( this ).children( '.acf-hint-description' ).width();
-		const dataKey = $( this ).data( 'key' );
-		if ( $( this ).hasClass( 'acf-hint-tooltip' ) ) {
-			tooltipWidths[ dataKey ] = width + 1;
-		}
-
-		// Initialize styles for loading screen.
-		$( this ).children( '.acf-hint-description' ).css( 'position', 'absolute' );
-		$( this ).children( '.acf-hint-description' ).css( 'display', 'none' );
-
 		// Change position of tooltips and switch button.
 		var $node = $( this ).parent().siblings( '.acf-label' ).find( 'label' );
 		$( this ).appendTo( $node );
@@ -44,13 +31,22 @@ jQuery(function( $ ) {
 			var $description = $( this ).children( '.acf-hint-description' );
 			$description.css( 'margin-top', '' );
 
-			// Set width of the tooltip.
-			const key = $( this ).data( 'key' );
-			const width = tooltipWidths[ key ];
-			$description.width( width );
+			// Calculates distance from icon to the right side of window. (and subtract 10px from the distance for the margin.)
+			const iconOffsetLeft = $( this ).offset().left;
+			const iconWidth = $( this ).children( '.hint-icon' ).width();
+			const iconToWindowDistance = window.innerWidth - ( iconOffsetLeft + iconWidth ) - 40;
 
-			// Display tooltip on screen.
-			$description.css( 'display', 'inline-block' );
+			// Add inline span tag to get width of the text.
+			$('<span>', { class: 'text', html: $description.html() })
+			.appendTo( $( this ).parents( '.acf-label' ) )
+			.css( 'visibility', 'hidden' );
+			// Get width of the text.
+			const textWidth = $(this).parents( '.acf-label' ).children('.text').width();
+			$(this).parents( '.acf-label' ).children('.text').remove();
+
+			// Set width of the tooltip.
+			let width = textWidth < iconToWindowDistance ? textWidth : iconToWindowDistance;
+			$description.width( width );
 
 			var descPosition = $description.offset(),
 				descHeight = $description.outerHeight();
@@ -61,7 +57,6 @@ jQuery(function( $ ) {
 		},
 		function () {
 			$( this ).removeClass( 'hover' );
-			$( this ).children( '.acf-hint-description' ).css( 'display', 'none' );
 		}
 	);
 });


### PR DESCRIPTION
## 修正内容
ツールチップの幅は固定にしていましたが、それだと文章量が増えた際に下に長くなってしまい見づらくなってしまってました。
そのため、文章の長さに合わせてツールチップの幅を自動調整するように修正しました。

調整は以下のように行いました。

### CSS
- cssの以下の指定を幅を取得するために削除。javascript側で操作するようにする。
     - width
     - display: none;
     - position: absolute;

### JavaScript
- ツールチップのDOMを.acf-input内から.acf-labelに移動する前に、.acf-input内でツールチップのwidthを取得する。
     - このときに、display: none;ではなく、opacity: 0;にすることで、widthを取得しています。

- アイコンにhoverされたときに、上記で取得していたwidthをツールチップのwidthに指定する

- display: none; とposition: absolute; を指定する。

## Before/After画像

### 修正前
<img width="500" alt="CRM契約マージ" src="https://user-images.githubusercontent.com/56631479/133750974-832aafff-6b7e-46a7-bf08-36a87200f333.png">


### 修正後
<img width="500" alt="CRM契約マージ修正後" src="https://user-images.githubusercontent.com/56631479/133751017-256724e2-71d7-44ae-a85e-be70300a957b.png">
