### PR TITLE
注釈用文章のフィルターフックを追加

### DIFF
--- a/acf-additional-hint.php
+++ b/acf-additional-hint.php
@@ -3,7 +3,7 @@
  * Plugin Name: ACF Additional Hint
  * Plugin URI:
  * Description: A plugin to add help/hint text in ACF field.
- * Version: 1.3
+ * Version: 1.4
  * Author: PRESSMAN
  * Author URI: https://www.pressman.ne.jp/
  * Text Domain: acf-additional-hint
@@ -120,6 +120,8 @@ class ACF_Additional_Hint {
 		if ( ! isset( $field['hint_text'] ) || ! $field['hint_text'] ) {
 			return;
 		}
+
+		$field['hint_text'] = apply_filters( 'acf_additional_hint/render_hint_text_field', $field['hint_text'] );
 
 		// In case of click_toggle.
 		if ( 'click_toggle' === $field['hint_toggler'] ) {


### PR DESCRIPTION
## 対応内容
- `acf_additional_hint/render_hint_text_field`というフィルターフックを追加。

## 対応背景
- 注釈に実体参照を入れたいときなど、入力した文字列をさらに加工して表示したい状況があったので、それに対応するために追加しました。（何もしないとフィールドグループの設定画面で実体参照を入力しても、変換後の文字列が表示されてしまう）